### PR TITLE
Remove calls to ERR_get_error_line_data deprecated with OpenSSL 3

### DIFF
--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -72,7 +72,7 @@ static void ssl_log_errors(const char* context) {
   const char* data;
   int flags;
   int err;
-  while ((err = ERR_get_error_line_data(NULL, NULL, &data, &flags)) != 0) {
+  while ((err = ERR_get_error_all(NULL, NULL, NULL, &data, &flags)) != 0) {
     char buf[256];
     ERR_error_string_n(err, buf, sizeof(buf));
     LOG_ERROR("%s: %s:%s", context, buf, (flags & ERR_TXT_STRING) ? data : "");
@@ -85,7 +85,7 @@ static std::string ssl_error_string() {
   int flags;
   int err;
   std::string error;
-  while ((err = ERR_get_error_line_data(NULL, NULL, &data, &flags)) != 0) {
+  while ((err = ERR_get_error_all(NULL, NULL, NULL, &data, &flags)) != 0) {
     char buf[256];
     ERR_error_string_n(err, buf, sizeof(buf));
     if (!error.empty()) error.push_back(',');


### PR DESCRIPTION
This change converts calls to the deprecated `ERR_get_error_line_data` method with the newer equivalent `ERR_get_error_all` with `func = NULL`.