### PR TITLE
Fix compile error from assigning constant length

### DIFF
--- a/src/third_party/rapidjson/rapidjson/document.h
+++ b/src/third_party/rapidjson/rapidjson/document.h
@@ -316,8 +316,6 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
-
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }
 


### PR DESCRIPTION
This fixes the following error when compiling with clang19:
```
/home/ec2-user/yugabyte-db-thirdparty.old/src/cassandra-cpp-driver-2.9.0-yb-14/src/third_party/rapidjson/rapidjson/document.h:319:82: error: cannot assign to non-static data member 'length' with const-qualified type 'const SizeType' (aka 'const unsigned int')
  319 |     GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
      |                                                                           ~~~~~~ ^
/home/ec2-user/yugabyte-db-thirdparty.old/src/cassandra-cpp-driver-2.9.0-yb-14/src/third_party/rapidjson/rapidjson/document.h:325:20: note: non-static data member 'length' declared const here
  325 |     const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
      |     ~~~~~~~~~~~~~~~^~~~~~
1 error generated.
```
The operator= is to a class with only const fields and is also unused. This definition was removed.