### PR TITLE
Fix undefined behavior from memset on non-trivially-copyable object

### DIFF
--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -148,7 +148,7 @@ void Md5::final(uint8_t* result) {
   result[14] = d_ >> 16;
   result[15] = d_ >> 24;
 
-  memset(this, 0, sizeof(Md5));
+  clear();
 }
 
 // This processes one or more 64-byte data blocks, but does NOT update
@@ -256,6 +256,12 @@ const uint8_t* Md5::body(const uint8_t* data, size_t size)
   d_ = d;
 
   return ptr;
+}
+
+void Md5::clear() {
+  lo_ = hi_ = a_ = b_ = c_ = d_ = 0;
+  memset(buffer_, 0, sizeof(buffer_));
+  memset(block_, 0, sizeof(block_));
 }
 
 } // namespace cass

--- a/src/md5.hpp
+++ b/src/md5.hpp
@@ -37,6 +37,8 @@ public:
 private:
   const uint8_t* body(const uint8_t* data, size_t size);
 
+  void clear();
+
 private:
   // Any 32-bit or wider unsigned integer data type will do
   typedef uint32_t MD5_u32plus;


### PR DESCRIPTION
Clang 21 catches the following undefined behavior:
```
[cassandra-cpp-driver (clang21, uninstrumented)] src/cassandra-cpp-driver-2.9.0-yb-15/src/md5.cpp:151:10: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'cass::Md5' [-Werror,-Wnontrivial-memcall]
[cassandra-cpp-driver (clang21, uninstrumented)]   151 |   memset(this, 0, sizeof(Md5));
[cassandra-cpp-driver (clang21, uninstrumented)]       |          ^
[cassandra-cpp-driver (clang21, uninstrumented)] src/cassandra-cpp-driver-2.9.0-yb-15/src/md5.cpp:151:10: note: explicitly cast the pointer to silence this warning
[cassandra-cpp-driver (clang21, uninstrumented)]   151 |   memset(this, 0, sizeof(Md5));
[cassandra-cpp-driver (clang21, uninstrumented)]       |          ^
[cassandra-cpp-driver (clang21, uninstrumented)]       |          (void*)
[cassandra-cpp-driver (clang21, uninstrumented)] 1 error generated.
```
From [cppreference for memset](https://en.cppreference.com/w/cpp/string/byte/memset):
> If the object is a potentially-overlapping subobject or is not TriviallyCopyable (e.g., scalar, C-compatible struct, or an array of trivially copyable type), the behavior is undefined.

So replacing memset call here with explicit zeroing of the Md5 object.